### PR TITLE
Make format transformation work

### DIFF
--- a/http/image.go
+++ b/http/image.go
@@ -94,7 +94,7 @@ func ImageHandler(config *iiifconfig.Config, driver iiifdriver.Driver, images_ca
 			(20160901/thisisaaronland)
 		*/
 
-		if transformation.HasTransformation() {
+		if transformation.HasTransformation() || image.Format() != transformation.Format {
 
 			cacheMiss.Add(1)
 


### PR DESCRIPTION
I think there is a kind of bug in the original repository, which does not occur there because of color being the default quality. In our fork level2.json was changed so that default is now the default quality. I don't know the reason for making that change. So another possibility to make format transformation work would have been to change color back to the default quality